### PR TITLE
Alternative fix of headless mode in ledger nano x

### DIFF
--- a/src/io.h
+++ b/src/io.h
@@ -35,9 +35,17 @@ extern io_state_t io_state;
 void io_seproxyhal_display(const bagl_element_t *element);
 unsigned char io_event(unsigned char channel);
 
-typedef void timeout_callback_fn_t(bool ux_allowed);
-void set_timer(int ms, timeout_callback_fn_t* cb);
-void clear_timer();
-
 bool device_is_unlocked();
+
+#if defined(TARGET_NANOS)
+typedef void timeout_callback_fn_t(bool ux_allowed);
+void nanos_set_timer(int ms, timeout_callback_fn_t* cb);
+void nanos_clear_timer();
+#elif defined(TARGET_NANOX)
+// we had to disable set_timer for Nano X, since in the new SDK UX_STEP_CB/UX_STEP_NOCB macros
+// automatically push a confirm callback to G_ux.stack[].ticker_callback with timeout zero
+// which causes other callbacks (i.e. ours) to be ignored in UX_TICKER_EVENT, so set_timer
+// does not actually work anymore in Nano X
+#endif
+
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -48,12 +48,12 @@ static const int INS_NONE = -1;
 // menu as its idle screen; you can define your own completely custom screen.
 void ui_idle(void)
 {
-	clear_timer();
 	currentInstruction = INS_NONE;
 	// The first argument is the starting index within menu_main, and the last
 	// argument is a preprocessor; I've never seen an app that uses either
 	// argument.
 	#if defined(TARGET_NANOS)
+	nanos_clear_timer();
 	UX_MENU_DISPLAY(0, menu_main, NULL);
 	#elif defined(TARGET_NANOX)
 	// reserve a display stack slot if none yet

--- a/src/uiHelpers.c
+++ b/src/uiHelpers.c
@@ -88,6 +88,15 @@ void ui_displayPrompt_headless_cb(bool ux_allowed)
 	})
 }
 
+void autoconfirmPrompt()
+{
+	#if defined(TARGET_NANOS)
+	nanos_set_timer(HEADLESS_DELAY, ui_displayPrompt_headless_cb);
+	#elif defined(TARGET_NANOX)
+	UX_CALLBACK_SET_INTERVAL(HEADLESS_DELAY);
+	#endif
+}
+
 void ui_displayPaginatedText_headless_cb(bool ux_allowed)
 {
 	TRACE("HEADLESS response");
@@ -101,6 +110,15 @@ void ui_displayPaginatedText_headless_cb(bool ux_allowed)
 		ASSERT(device_is_unlocked() == true);
 		uiCallback_confirm(&paginatedTextState->callback);
 	});
+}
+
+void autoconfirmPaginatedText()
+{
+	#if defined(TARGET_NANOS)
+	nanos_set_timer(HEADLESS_DELAY, ui_displayPaginatedText_headless_cb);
+	#elif defined(TARGET_NANOX)
+	UX_CALLBACK_SET_INTERVAL(HEADLESS_DELAY);
+	#endif
 }
 
 #endif
@@ -141,7 +159,7 @@ void ui_displayPrompt(
 
 	#ifdef HEADLESS
 	if (confirm) {
-		set_timer(HEADLESS_DELAY, ui_displayPrompt_headless_cb);
+		autoconfirmPrompt();
 	}
 	#endif
 }
@@ -185,7 +203,7 @@ void ui_displayPaginatedText(
 
 	#ifdef HEADLESS
 	if (callback) {
-		set_timer(HEADLESS_DELAY, ui_displayPaginatedText_headless_cb);
+		autoconfirmPaginatedText();
 	}
 	#endif
 }


### PR DESCRIPTION
Alternative fix of headless mode in Ledger Nano X, triggering autoconfirm by UX_CALLBACK_SET_INTERVAL